### PR TITLE
Handle empty strings in pandas.js parser.

### DIFF
--- a/js/wq/pandas.js
+++ b/js/wq/pandas.js
@@ -63,7 +63,7 @@ pandas.parse = function(str) {
             var key, val;
             for (key in row) {
                 val = row[key];
-                row[key] = isNaN(+val) ? val : +val;
+                row[key] = val.length>0 ? (isNaN(+val) ? val : +val) : '';
             }
             data.push(row);
         });


### PR DESCRIPTION
Empty strings evaluate as '0' if prefixed with a '+'. This makes handling missing values cumbersome. This patch makes sure that empty strings are passed on as empty strings.