### PR TITLE
improve outbox memory handling

### DIFF
--- a/js/wq/app.js
+++ b/js/wq/app.js
@@ -1659,12 +1659,12 @@ function _parent_dropdown_lookup(field, context, nkey) {
 function _getOutboxRecords(model) {
     return model.unsyncedItems().then(function(items) {
         return items.map(function(item) {
-            var record = item.data;
-            record.label = item.label;
-            record.id = 'outbox-' + item.id;
-            record.outbox_id = item.id;
-            record.outbox = true;
-            return record;
+            return {
+                'id': 'outbox-' + item.id,
+                'label': item.label,
+                'outbox_id': item.id,
+                'outbox': true
+            };
         });
     });
 }

--- a/js/wq/model.js
+++ b/js/wq/model.js
@@ -362,7 +362,7 @@ function Model(config) {
     };
 
     // Unsaved form items related to this list
-    self.unsyncedItems = function() {
+    self.unsyncedItems = function(withData) {
         // Note: wq/outbox needs to have already been loaded for this to work
         var outbox;
         try {
@@ -372,7 +372,7 @@ function Model(config) {
         }
         return outbox.getOutbox(
             self.store
-        ).unsyncedItems(self.query);
+        ).unsyncedItems(self.query, withData);
     };
 
     // Apply a predefined function to a retreived item

--- a/js/wq/model.js
+++ b/js/wq/model.js
@@ -119,6 +119,8 @@ function Model(config) {
         });
     }
 
+    self._processData = _processData;
+
     function _processData(data) {
         if (!data) {
             data = [];

--- a/js/wq/photos.js
+++ b/js/wq/photos.js
@@ -8,8 +8,8 @@
 /* global Camera */
 
 define(['jquery', 'jquery.mobile', 'localforage',
-        './template', './store', './spinner'],
-function($, jqm, localForage, tmpl, ds, spin) {
+        './template', './spinner'],
+function($, jqm, localForage, tmpl, spin) {
 
 var LOCALFORAGE_PREFIX = '__lfsc__:blob~~local_forage_type~image/jpeg~';
 
@@ -97,6 +97,8 @@ photos.base64toBlob = function(data) {
     });
 };
 
+photos._files = {};
+
 photos.storeFile = function(name, type, blob, input) {
     // Save blob data for later retrieval
     var file = {
@@ -104,11 +106,10 @@ photos.storeFile = function(name, type, blob, input) {
         'type': type,
         'body': blob
     };
-    return ds.set(name, file).then(function() {
-        if (input) {
-            $('#' + input).val(name);
-        }
-    });
+    photos._files[name] = file;
+    if (input) {
+        $('#' + input).val(name);
+    }
 };
 
 function load(data, input, preview) {
@@ -116,12 +117,11 @@ function load(data, input, preview) {
     photos.base64toBlob(data).then(function(blob) {
         var number = Math.round(Math.random() * 1e10);
         var name = $('#' + input).val() || ('photo' + number + '.jpg');
-        photos.storeFile(name, 'image/jpeg', blob, input).then(function() {
-            spin.stop();
-            if (preview) {
-                photos.preview(preview, blob);
-            }
-        });
+        photos.storeFile(name, 'image/jpeg', blob, input);
+        spin.stop();
+        if (preview) {
+            photos.preview(preview, blob);
+        }
     });
 }
 

--- a/js/wq/store.js
+++ b/js/wq/store.js
@@ -149,7 +149,7 @@ function _Store(name) {
             return self.lf.setItem(key, value).then(function(d) {
                 return d;
             }, function(err) {
-                self.storageFail(value, err);
+                return self.storageFail(value, err);
             });
         }
     };
@@ -157,7 +157,7 @@ function _Store(name) {
     // Callback for localStorage failure - override to inform the user
     self.storageFail = function(item, error) {
         /* jshint unused: false */
-        self.storageUsage().then(function(usage) {
+        return self.storageUsage().then(function(usage) {
             var msg;
             if (usage > 0) {
                 msg = "Storage appears to be full.";
@@ -166,6 +166,7 @@ function _Store(name) {
             }
             console.warn(msg + "  Caught Error:");
             console.warn(error && error.stack || error);
+            throw new Error(msg);
         });
     };
 

--- a/tests/js/suite/main.js
+++ b/tests/js/suite/main.js
@@ -4,6 +4,7 @@ define([
     './store',
     './map',
     './pandas',
+    './outbox',
 ], function() {
     var tests = Array.prototype.slice.call(arguments);
     Promise.all(tests).then(function() {

--- a/tests/js/suite/outbox.js
+++ b/tests/js/suite/outbox.js
@@ -1,0 +1,106 @@
+define(['./app', 'wq/store', 'wq/outbox'], function(appTests, ds, outbox) {
+
+QUnit.module('wq/outbox');
+
+QUnit.test("form with no explicit storage", function(assert) {
+    testOutbox({
+        'assert': assert,
+        'data': {'test': 123},
+        'options': {},
+        'expectItem': {
+            'id': 1,
+            'synced': false,
+            'data': {'test': 123},
+            'options': {}
+        },
+        'expectStored': null
+    });
+});
+
+QUnit.test("form with storage=store", function(assert) {
+    var blob = new Blob([1,2,3], {'type': 'text/plain'});
+    testOutbox({
+        'assert': assert,
+        'data': {
+            'file': {
+                  'type': 'text/plain',
+                  'name': 'test.txt',
+                  'body': blob
+             }
+        },
+        'options': {
+            'storage': 'store'
+        },
+        'expectItem': {
+            'id': 1,
+            'synced': false,
+            'options': {
+                'storage': 'store'
+            }
+        },
+        'expectStored': {
+            'file': {
+                 'type': 'text/plain',
+                 'name': 'test.txt',
+                 'body': blob
+            }
+        }
+    });
+});
+
+QUnit.test("form with storage=temporary", function(assert) {
+    testOutbox({
+        'assert': assert,
+        'data': {'secret': 'code'},
+        'options': {
+            'storage': 'temporary'
+        },
+        'expectItem': {
+            'id': 1,
+            'synced': false,
+            'options': {
+                'storage': 'temporary'
+            }
+        },
+        'expectStored': null
+    });
+});
+
+function testOutbox(test) {
+    var assert = test.assert,
+        done = assert.async();
+    outbox.model.overwrite([]).then(function() {
+        return outbox.save(test.data, test.options, true);
+    }).then(function() {
+        return ds.get('outbox');
+    }).then(function(actualOutbox) {
+        var expectOutbox = {
+            "list": [test.expectItem],
+            "pages": 1,
+            "count": 1,
+            "per_page": 1
+        };
+        assert.deepEqual(
+            actualOutbox,
+            expectOutbox,
+            'inlined item data should be: ' +
+            JSON.stringify(test.expectItem.data)
+        );
+        return ds.get('outbox_1');
+    }).then(function(actualStored) {
+        assert.deepEqual(
+            actualStored,
+            test.expectStored,
+            'stored item data should be: ' + JSON.stringify(test.expectStored)
+        );
+        return outbox.loadItem(1);
+    }).then(function(actualItem) {
+        assert.deepEqual(
+            actualItem.data,
+            test.data,
+            'reconstituted item data should be: ' + JSON.stringify(test.data)
+        );
+    }).then(done);
+}
+
+});


### PR DESCRIPTION
 - don't store form data if wq-background-sync is false (fixes #90)
 - store form data containing files/blobs under separate localForage keys
 - don't load blobs for outbox items unless explicitly requested (with new `outbox.loadItem()` method)
 - fall back to in-memory storage if localForage cannot save form contents
 - don't attempt to store wq/photo.js blobs until form submission
 - enable context & run plugins for outbox view