### PR TITLE
create parent_url for outbox items

### DIFF
--- a/js/wq/app.js
+++ b/js/wq/app.js
@@ -680,7 +680,8 @@ _register.list = function(page) {
                 spin.stop();
                 var context = {
                     'parent_id': match[1],
-                    'parent_url': pitem && (pconf.url + '/' + pitem.id),
+                    'parent_url': (pitem && (pconf.url + '/' + pitem.id)) ||
+                                  ('outbox/' + match[1].split('-')[1]),
                     'parent_label': pitem && pitem.label,
                     'parent_page': ppage
                 };


### PR DESCRIPTION
If the parent item is unsynced, in the list views only three fields are set e.g.:

1. `parent_id="outbox-5"`
2. `parent_is_something=true`
3. `parent_page="something"`

To create a link to the parent, one would need to extract the `outbox_id` and this can't be done in the templating language. 

Let's create also something like `parent_url="outbox/5"` useful for e.g. a "Back" button.