### PR TITLE
make _loadFromServer respect the base_url setting

### DIFF
--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -1894,7 +1894,7 @@ function _computeFilter(filter, context) {
 }
 
 function _loadFromServer(url, ui) {
-    var jqmurl = '/' + url,
+    var jqmurl = app.base_url + '/' + url,
         options = (ui && ui.options) || {};
     options.wqSkip = true;
     if (app.config.debug) {


### PR DESCRIPTION
Make _loadFromServer respect the base_url setting.  That way when we
serve wq from a non-root(/) path, the routing works correctly.  For
example, try.wq.io "View All Observations" 404s without this.